### PR TITLE
Added build options for test and benchmark in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,9 @@ find_file(BLIS_H blis REQUIRED) # find path to blis.h file; store in BLIS_H
 find_file(MARRAY_H marray REQUIRED)
 
 add_subdirectory(src) # build library
-add_subdirectory(test) # build tests
-add_subdirectory(benchmark) # build benchmarks
+if(T1M_BUILD_TEST)
+  add_subdirectory(test) # build tests
+endif()
+if(T1M_BUILD_BENCHMARK)
+  add_subdirectory(benchmark) # build benchmarks
+endif()


### PR DESCRIPTION
I added some build options for subdirectories test and benchmark. They can still be built via -DT1M_BUILD_TEST=ON, -DT1M_BUILD_BENCHMARK=ON, if needed.

Btw, Ive seen that you're trying to make the library more accessible in https://github.com/MatthiasReumann/t1m/pull/6.
Im currently including your project into mine using
```
FetchContent_Declare(
    marray
    GIT_REPOSITORY https://github.com/devinamatthews/marray.git
)
FetchContent_MakeAvailable(marray)
set(MARRAY_H ${marray_SOURCE_DIR}/marray)

FetchContent_Declare(
    t1m
    GIT_REPOSITORY https://github.com/willnerNCP/t1m.git
    GIT_TAG main
)
FetchContent_MakeAvailable(t1m)
target_compile_options(t1m PRIVATE -O3 -fpermissive)

[...]
target_include_directories(myproject PUBLIC
    [...]
    ${t1m_SOURCE_DIR}/include/t1m
)
target_link_libraries(myproject
    [...]
    t1m
)
```
which works pretty well for me :) Thanks for the lib btw, amazing work. Cheers, Marius